### PR TITLE
Enhance documentation for Copilot Agents demo and issue guidelines

### DIFF
--- a/demos/copilot-agents/ISSUE.md
+++ b/demos/copilot-agents/ISSUE.md
@@ -21,5 +21,4 @@ We want to add a Priority system to our triage policy so tickets are handled con
 
 ### Acceptance criteria
 - The README has a Priority section with definitions
-- There is a simple mapping table or bullet mapping
 - There is a short triage checklist

--- a/demos/copilot-agents/ISSUE.md
+++ b/demos/copilot-agents/ISSUE.md
@@ -2,7 +2,6 @@
 
 1) Use the Title tag below for your Issue name. 
 2) Paste the Body section into the issue.
-3) Assign Copilot to have an agent start the task! 
 
 ---
 

--- a/demos/copilot-agents/ISSUE.md
+++ b/demos/copilot-agents/ISSUE.md
@@ -1,0 +1,26 @@
+# ISSUE.md
+
+1) Use the Title tag below for your Issue name. 
+2) Paste the Body section into the issue.
+3) Assign Copilot to have an agent start the task! 
+
+---
+
+## Title
+Add Priority levels to the triage policy
+
+## Body
+
+### Goal
+We want to add a Priority system to our triage policy so tickets are handled consistently.
+
+### Requirements
+- Add Priority levels P0, P1, P2, P3 and define what each means
+- Add a clear mapping from Severity to default Priority
+- Add a short “How to triage in 60 seconds” checklist
+- Keep it concise and easy for engineers to follow
+
+### Acceptance criteria
+- The README has a Priority section with definitions
+- There is a simple mapping table or bullet mapping
+- There is a short triage checklist

--- a/demos/copilot-agents/README.md
+++ b/demos/copilot-agents/README.md
@@ -1,6 +1,10 @@
-# Copilot Agents Demo (No Setup)
+# Copilot Agents Demo
 
-This repository is intentionally minimal so you can demo GitHub Copilot Agents with zero local setup. The only “live” step in the demo is creating an issue and assigning it to Copilot so the agent returns a pull request you can review.
+Use the following 3 files to setup your Copilot Agents demo. 
+Create a repo with the same README file as this one.
+Paste the ISSUE.md file into a new issue in that repository. 
+Assign Copilot to the new Issue in the new repository.
+Use the STEER.md file to course correct the agent mid session. 
 
 ## What this demo shows
 - Assign an issue to Copilot to start an agent task

--- a/demos/copilot-agents/README.md
+++ b/demos/copilot-agents/README.md
@@ -1,7 +1,6 @@
 # Copilot Agents Demo
 
 Use the following 3 files to setup your Copilot Agents demo. 
-Create a repo with the same README file as this one.
 Paste the ISSUE.md file into a new issue in that repository. 
 Assign Copilot to the new Issue in the new repository.
 Use the STEER.md file to course correct the agent mid session. 

--- a/demos/copilot-agents/README.md
+++ b/demos/copilot-agents/README.md
@@ -21,7 +21,8 @@ Use the STEER.md file to course correct the agent mid session.
 2. Assign the issue to Copilot to start the agent task
 3. Open AgentHQ to monitor progress
 4. Paste `STEER.md` into the agent session to re-steer the work
-5. Review the PR diff for clarity, completeness, and constraints
+5. Review the PR diff for clarity, completeness, and constraints.
+6. Verify the PR edited the README.md file by adding priority levels plus the steered examples. 
 
 ---
 

--- a/demos/copilot-agents/README.md
+++ b/demos/copilot-agents/README.md
@@ -1,0 +1,36 @@
+# Copilot Agents Demo (No Setup)
+
+This repository is intentionally minimal so you can demo GitHub Copilot Agents with zero local setup. The only “live” step in the demo is creating an issue and assigning it to Copilot so the agent returns a pull request you can review.
+
+## What this demo shows
+- Assign an issue to Copilot to start an agent task
+- Monitor progress in AgentHQ
+- Re-steer mid-session with a new requirement
+- Review the resulting PR like a teammate’s work
+
+## Demo files
+- `ISSUE.md` contains the exact issue text to copy/paste into GitHub
+- `STEER.md` contains the mid-session requirement change to paste while the agent is working
+
+## Quick demo steps
+1. Create a new GitHub Issue by copying the Title and Body from `ISSUE.md`
+2. Assign the issue to Copilot to start the agent task
+3. Open AgentHQ to monitor progress
+4. Paste `STEER.md` into the agent session to re-steer the work
+5. Review the PR diff for clarity, completeness, and constraints
+
+---
+
+## Ticket Triage Policy (Current)
+
+We currently triage support tickets using Severity only.
+
+### Severity levels
+- Low means minor annoyance with an easy workaround
+- Medium means a meaningful user impact but workarounds exist
+- High means blocks key workflows or causes data loss
+
+### Current rules
+- Triage happens daily
+- High severity should be addressed first
+- We do not currently define priority labels, default ownership, or a fast triage checklist

--- a/demos/copilot-agents/README.md
+++ b/demos/copilot-agents/README.md
@@ -2,7 +2,6 @@
 
 Use the following 3 files to setup your Copilot Agents demo. 
 Paste the ISSUE.md file into a new issue in that repository. 
-Assign Copilot to the new Issue in the new repository.
 Use the STEER.md file to course correct the agent mid session. 
 
 ## What this demo shows

--- a/demos/copilot-agents/README.md
+++ b/demos/copilot-agents/README.md
@@ -2,7 +2,6 @@
 
 Use the following 3 files to setup your Copilot Agents demo. 
 Paste the ISSUE.md file into a new issue in that repository. 
-Use the STEER.md file to course correct the agent mid session. 
 
 ## What this demo shows
 - Assign an issue to Copilot to start an agent task

--- a/demos/copilot-agents/STEER.md
+++ b/demos/copilot-agents/STEER.md
@@ -1,0 +1,7 @@
+# STEER.md
+
+Paste this into the agent session after the task has started.
+
+New requirement:
+Please include 3 realistic example tickets and show how they get assigned a Priority using the new rules.
+Also keep the whole policy to one screen of text if possible.

--- a/demos/copilot-agents/STEER.md
+++ b/demos/copilot-agents/STEER.md
@@ -3,5 +3,4 @@
 Paste this into the agent session after the task has started.
 
 New requirement:
-Please include 3 realistic example tickets and show how they get assigned a Priority using the new rules.
 Also keep the whole policy to one screen of text if possible.


### PR DESCRIPTION
This pull request adds a demo setup for Copilot Agents, including instructions and materials for running a live demo that showcases agent-driven issue triage and mid-session steering. The main changes introduce three new files: a README with setup and policy context, an ISSUE template for the demo, and a STEER file for mid-session requirement changes.

The most important changes are:

**Demo Setup and Documentation:**
* Added `README.md` with step-by-step instructions for setting up and running the Copilot Agents demo, including a description of the current ticket triage policy and how to use the provided files.

**Agent Task and Workflow Templates:**
* Added `ISSUE.md` template for creating a new GitHub issue that instructs Copilot to add priority levels to the triage policy, with goals, requirements, and acceptance criteria.
* Added `STEER.md` file providing a mid-session requirement change, instructing the agent to include realistic example tickets and keep the policy concise.