### PR TITLE
Enhance README with bonus GitHub review tip

### DIFF
--- a/demos/copilot-features/README.md
+++ b/demos/copilot-features/README.md
@@ -90,7 +90,7 @@ python -m pytest -q      # sanity check – should pass
 
 <br />
 
-> 📋 **BONUS**: If you'd like to review the repository on GitHub.com, you can select "Give me a high-level overview" to learn more about the repository. This does require you to pull it up on the dot com and not through the command line but it does help provide useful insights for fundamental users who are touching a codebase that they are not familiar with.  
+> 📋 **BONUS**: If you'd like to review the repository on GitHub.com, open the repository and select the Copilot icon in the upper-right corner. In the dropdown menu, select “Give me a high-level overview” to learn more about the repository. This experience is available on GitHub.com rather than through the command line and can provide useful context for fundamental users working with an unfamiliar codebase.
 ---
 
 ## 🔍 Phase 1 · Plan (≤ 5 min)

--- a/demos/copilot-features/README.md
+++ b/demos/copilot-features/README.md
@@ -88,6 +88,9 @@ python -m pytest -q      # sanity check – should pass
 1. **Enable Copilot Chat** → _VS Code › View › Copilot Chat_.  
 2. Type `print("globex")` – ensure 💡 suggestions appear.
 
+</br>
+
+> 📋 **BONUS**: If you'd like to review the repository on GitHub.com, you can select "Give me a high-level overiew" to learn more about the repository. This does require you to pull it up on the dot com and not through the command line but it does help provide useful insights for fundamental users who are touching a codebase that they are not familiar with.  
 ---
 
 ## 🔍 Phase 1 · Plan (≤ 5 min)

--- a/demos/copilot-features/README.md
+++ b/demos/copilot-features/README.md
@@ -90,7 +90,7 @@ python -m pytest -q      # sanity check – should pass
 
 <br />
 
-> 📋 **BONUS**: If you'd like to review the repository on GitHub.com, you can select "Give me a high-level overiew" to learn more about the repository. This does require you to pull it up on the dot com and not through the command line but it does help provide useful insights for fundamental users who are touching a codebase that they are not familiar with.  
+> 📋 **BONUS**: If you'd like to review the repository on GitHub.com, you can select "Give me a high-level overview" to learn more about the repository. This does require you to pull it up on the dot com and not through the command line but it does help provide useful insights for fundamental users who are touching a codebase that they are not familiar with.  
 ---
 
 ## 🔍 Phase 1 · Plan (≤ 5 min)

--- a/demos/copilot-features/README.md
+++ b/demos/copilot-features/README.md
@@ -88,7 +88,7 @@ python -m pytest -q      # sanity check – should pass
 1. **Enable Copilot Chat** → _VS Code › View › Copilot Chat_.  
 2. Type `print("globex")` – ensure 💡 suggestions appear.
 
-</br>
+<br />
 
 > 📋 **BONUS**: If you'd like to review the repository on GitHub.com, you can select "Give me a high-level overiew" to learn more about the repository. This does require you to pull it up on the dot com and not through the command line but it does help provide useful insights for fundamental users who are touching a codebase that they are not familiar with.  
 ---


### PR DESCRIPTION
This pull request adds a helpful tip to the `demos/copilot-features/README.md` file, suggesting users can get a high-level overview of a repository on GitHub.com. This aims to assist users who are new to a codebase.

Documentation improvements:

* Added a "BONUS" tip explaining how to use the "Give me a high-level overview" feature on GitHub.com to quickly learn about a repository.
